### PR TITLE
Fix Travis

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -410,7 +410,7 @@ class JRouterSite extends JRouter
 	/**
 	 * Function to build a raw route
 	 *
-	 * @param   JUri    &$uri  The internal URL
+	 * @param   JUri  &$uri  The internal URL
 	 *
 	 * @return  string  Raw Route
 	 *


### PR DESCRIPTION
@Hackwar this should fix this travis issues:

```
FILE: /home/travis/build/joomla/joomla-cms/libraries/cms/router/site.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
413 | ERROR | Expected 2 spaces after the longest type
--------------------------------------------------------------------------------
```

see: https://travis-ci.org/joomla/joomla-cms/jobs/34017263

The others are the `assertTag is deprecated` messages :D
