### PR TITLE
 Email templates. Show/hide tags section. Do not allow to add tag in to disabled input

### DIFF
--- a/administrator/components/com_mails/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/Helper/MailsHelper.php
@@ -45,8 +45,8 @@ abstract class MailsHelper
 		foreach ($mail->params['tags'] as $tag)
 		{
 			$html .= '<li class="list-group-item">'
-				. '<a href="#" onclick="Joomla.editors.instances[\'jform_' . $fieldname . '\'].replaceSelection(\'{' . strtoupper($tag) . '}\');'
-					. 'return false;" title="' . $tag . '">' . $tag . '</a>'
+				. '<a href="#" class="edit-action-add-tag" data-tag="{' . strtoupper($tag) . '}" data-target="' . $fieldname . '"'
+					. ' title="' . $tag . '">' . $tag . '</a>'
 				. '</li>';
 		}
 

--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -17,32 +17,20 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Mails\Administrator\Helper\MailsHelper;
 
+$app = Factory::getApplication();
+$doc = Factory::getDocument();
+
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
+HTMLHelper::_('script', 'com_mails/admin-email-template-edit.min.js', ['version' => 'auto', 'relative' => true]);
 
 $this->useCoreUI = true;
 
-$app = Factory::getApplication();
 $input = $app->input;
 list($component, $sub_id) = explode('.', $this->master->template_id, 2);
 
-$doc = Factory::getDocument();
-$doc->addScriptDeclaration('
-document.addEventListener(\'DOMContentLoaded\', () => {
-	var templateData = ' . json_encode($this->templateData) . ';
-	document.querySelectorAll(\'#item-form joomla-field-switcher\').forEach(function (el) {
-		el.addEventListener(\'joomla.switcher.on\', function() {
-			var el2 = document.getElementById(this.id.substring(0, this.id.length - 9));
-			el2.disabled = false;
-			el2.value = templateData[this.id.slice(6, -9)].translated;
-		});
-		el.addEventListener(\'joomla.switcher.off\', function() {
-			var el2 = document.getElementById(this.id.substring(0, this.id.length - 9));
-			el2.disabled = true;
-			el2.value = templateData[this.id.slice(6, -9)].master;
-		});
-	});
-});');
+$doc->addScriptOptions('com_mails', ['templateData' => $this->templateData]);
+
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_mails&layout=edit&template_id=' . $this->item->template_id . '&language=' . $this->item->language); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -56,28 +56,32 @@ $doc->addScriptOptions('com_mails', ['templateData' => $this->templateData]);
 			</div>
 		</div>
 
-		<?php if ($this->form->getField('body')) : ?>
+		<?php if ($fieldBody = $this->form->getField('body')) : ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php echo $this->form->renderField('body'); ?>
 			</div>
 			<div class="col-md-3">
 				<?php echo $this->form->getField('body_switcher')->input; ?>
-				<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
-				<?php echo MailsHelper::mailtags($this->master, 'body'); ?>
+				<div class="tags-container-body <?php echo $fieldBody->disabled ? 'hidden' : ''; ?>">
+					<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
+					<?php echo MailsHelper::mailtags($this->master, 'body'); ?>
+				</div>
 			</div>
 		</div>
 		<?php endif; ?>
 
-		<?php if ($this->form->getField('htmlbody')) : ?>
+		<?php if ($fieldHtmlBody = $this->form->getField('htmlbody')) : ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php echo $this->form->renderField('htmlbody'); ?>
 			</div>
 			<div class="col-md-3">
 				<?php echo $this->form->getField('htmlbody_switcher')->input; ?>
-				<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
-				<?php echo MailsHelper::mailtags($this->master, 'htmlbody'); ?>
+				<div class="tags-container-htmlbody <?php echo $fieldHtmlBody->disabled ? 'hidden' : ''; ?>">
+					<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
+					<?php echo MailsHelper::mailtags($this->master, 'htmlbody'); ?>
+				</div>
 			</div>
 		</div>
 		<?php endif; ?>

--- a/build/media_src/com_mails/js/admin-email-template-edit.es6.js
+++ b/build/media_src/com_mails/js/admin-email-template-edit.es6.js
@@ -1,0 +1,95 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+((document, Joomla) => {
+  'use strict';
+
+  class EmailTemplateEdit {
+
+    constructor(form, options) {
+      this.form = form;
+      this.templateData = options && options.templateData ? options.templateData : {};
+      this.inputSubject = this.form.querySelector('#jform_subject');
+      this.inputBody    = this.form.querySelector('#jform_body');
+      this.inputHtmlBody = this.form.querySelector('#jform_htmlbody');
+
+      console.log(this);
+    }
+
+    setBodyValue(value) {
+      if (this.inputBody.disabled) {
+        return;
+      }
+
+      if (Joomla.editors.instances[this.inputBody.id]) {
+        Joomla.editors.instances[this.inputBody.id].setValue(value);
+      } else {
+        this.inputBody.value = value;
+      }
+    }
+
+    setHtmlBodyValue(value) {
+      if (this.inputHtmlBody.disabled) {
+        return;
+      }
+
+      if (Joomla.editors.instances[this.inputHtmlBody.id]) {
+        Joomla.editors.instances[this.inputHtmlBody.id].setValue(value);
+      } else {
+        this.inputHtmlBody.value = value;
+      }
+    }
+
+    bindListeners() {
+      this.form.addEventListener('joomla.switcher.on', (event) => {
+        const type = event.target.id.slice(6, -9);
+        const inputValue = this.templateData[type] ? this.templateData[type].translated : '';
+
+        switch (type) {
+          case 'subject':
+            this.inputSubject.disabled = false;
+            this.inputSubject.value = inputValue;
+            break;
+          case 'body':
+            this.inputBody.disabled = false;
+            this.setBodyValue(inputValue);
+            break;
+          case 'htmlbody':
+            this.inputHtmlBody.disabled = false;
+            this.setHtmlBodyValue(inputValue);
+            break;
+        }
+      });
+
+      this.form.addEventListener('joomla.switcher.off', (event) => {
+        const type = event.target.id.slice(6, -9);
+        const inputValue = this.templateData[type] ? this.templateData[type].master : '';
+
+        switch (type) {
+          case 'subject':
+            this.inputSubject.disabled = true;
+            this.inputSubject.value = inputValue;
+            break;
+          case 'body':
+            this.setBodyValue(inputValue);
+            this.inputBody.disabled = true;
+            break;
+          case 'htmlbody':
+            this.setHtmlBodyValue(inputValue);
+            this.inputHtmlBody.disabled = true;
+            break;
+        }
+
+      });
+    }
+
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const editor = new EmailTemplateEdit(document.getElementById('item-form'), Joomla.getOptions('com_mails'));
+    editor.bindListeners();
+  });
+
+})(document, Joomla);


### PR DESCRIPTION
This is update to your Pull request https://github.com/joomla/joomla-cms/pull/22126

I have moved JS to separated file. 
And changed a bit, so now it show/hide tags section, and use editor API to insert/replace values.
Also if an input are disabled then not possible to insert a tag.

