### PR TITLE
Remove obsolete columns from SQL statements

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-01-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-01-16.sql
@@ -1,5 +1,5 @@
-INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-('com_mails', 'component', 'com_mails', '', 1, 1, 1, 1, '{"name":"com_mails","type":"component","creationDate":"January 2019","author":"Joomla! Project","copyright":"(C) 2005 - 2018 Open Source Matters. All rights reserved.","authorEmail":"admin@joomla.org","authorUrl":"www.joomla.org","version":"4.0.0","description":"COM_MAILS_XML_DESCRIPTION","group":""}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+('com_mails', 'component', 'com_mails', '', 1, 1, 1, 1, '{"name":"com_mails","type":"component","creationDate":"January 2019","author":"Joomla! Project","copyright":"(C) 2005 - 2018 Open Source Matters. All rights reserved.","authorEmail":"admin@joomla.org","authorUrl":"www.joomla.org","version":"4.0.0","description":"COM_MAILS_XML_DESCRIPTION","group":""}', '{}', 0, '0000-00-00 00:00:00', 0, 0);
 
 CREATE TABLE IF NOT EXISTS `#__mail_templates` (
   `template_id` VARCHAR(127) NOT NULL DEFAULT '',

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-01-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-01-16.sql
@@ -1,5 +1,5 @@
-INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-('com_mails', 'component', 'com_mails', '', 1, 1, 1, 1, '{"name":"com_mails","type":"component","creationDate":"January 2019","author":"Joomla! Project","copyright":"(C) 2005 - 2019 Open Source Matters. All rights reserved.","authorEmail":"admin@joomla.org","authorUrl":"www.joomla.org","version":"4.0.0","description":"COM_MAILS_XML_DESCRIPTION","group":""}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+('com_mails', 'component', 'com_mails', '', 1, 1, 1, 1, '{"name":"com_mails","type":"component","creationDate":"January 2019","author":"Joomla! Project","copyright":"(C) 2005 - 2019 Open Source Matters. All rights reserved.","authorEmail":"admin@joomla.org","authorUrl":"www.joomla.org","version":"4.0.0","description":"COM_MAILS_XML_DESCRIPTION","group":""}', '{}', 0, '1970-01-01 00:00:00', 0, 0);
 
 CREATE TABLE IF NOT EXISTS "#__mail_templates" (
   "template_id" varchar(127) NOT NULL DEFAULT '',

--- a/administrator/components/com_mails/Controller/DisplayController.php
+++ b/administrator/components/com_mails/Controller/DisplayController.php
@@ -11,7 +11,7 @@ namespace Joomla\Component\Mails\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\MVC\Controller\BaseController as BaseController;
+use Joomla\CMS\MVC\Controller\BaseController;
 
 /**
  * Mail templates Controller

--- a/administrator/components/com_mails/services/provider.php
+++ b/administrator/components/com_mails/services/provider.php
@@ -41,7 +41,7 @@ return new class implements ServiceProviderInterface
 
 		$container->set(
 			ComponentInterface::class,
-			function (Container $container)
+			static function (Container $container)
 			{
 				$component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 


### PR DESCRIPTION
@Hackwar The SQL statements are outdated as they contain 2 columns that no longer exist, this PR fixes that.

In addition 2 minor code cleanups.