### PR TITLE
Editor disabled

### DIFF
--- a/administrator/components/com_mails/Model/TemplateModel.php
+++ b/administrator/components/com_mails/Model/TemplateModel.php
@@ -61,15 +61,12 @@ class TemplateModel extends AdminModel
 	 * @param   array    $data      An optional array of data for the form to interogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  JForm  A JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|bool  A JForm object on success, false on failure
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
-		// Initialise variables.
-		$app = Factory::getApplication();
-
 		// Get the form.
 		$form = $this->loadForm('com_mails.template', 'template', array('control' => 'jform', 'load_data' => $loadData));
 

--- a/build/media_source/com_mails/js/admin-email-template-edit.es6.js
+++ b/build/media_source/com_mails/js/admin-email-template-edit.es6.js
@@ -117,7 +117,7 @@
       });
 
       const htmlBodySwitcherChangeHandler = (event) => {
-        const tagsContainer = this.form.querySelector('.tags-container-body');
+        const tagsContainer = this.form.querySelector('.tags-container-htmlbody');
 
         if (event.target.value === '0') {
           this.setHtmlBodyValue(this.templateData.htmlbody ? this.templateData.htmlbody.master : '');

--- a/build/media_source/com_mails/js/admin-email-template-edit.es6.js
+++ b/build/media_source/com_mails/js/admin-email-template-edit.es6.js
@@ -121,11 +121,10 @@
 
         if (event.target.value === '0') {
           this.setHtmlBodyValue(this.templateData.htmlbody ? this.templateData.htmlbody.master : '');
-          this.inputHtmlBody.disabled = true;
+          Joomla.editors.instances[this.inputHtmlBody.id].disable(true);
           tagsContainer.classList.add('hidden');
         } else if (event.target.value === '1') {
-          this.inputHtmlBody.disabled = false;
-          this.inputHtmlBody.readOnly = false;
+          Joomla.editors.instances[this.inputHtmlBody.id].disable(false);
           this.setHtmlBodyValue(this.templateData.htmlbody ? this.templateData.htmlbody.translated : '');
           tagsContainer.classList.remove('hidden');
         } else {

--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -103,6 +103,7 @@ customElements.define('joomla-editor-codemirror', class extends HTMLElement {
 
             // Register Editor
             this.instance = window.CodeMirror.fromTextArea(this.element, this.options);
+            this.instance.disable = disabled => this.instance.setOption('readOnly', disabled ? 'nocursor' : false);
             Joomla.editors.instances[this.element.id] = this.instance;
           });
       });

--- a/build/media_source/plg_editors_none/js/joomla-editor-none.w-c.es6.js
+++ b/build/media_source/plg_editors_none/js/joomla-editor-none.w-c.es6.js
@@ -38,16 +38,6 @@ window.customElements.define('joomla-editor-none', class extends HTMLElement {
   }
 
   /**
-   * Sets if the editor should be disabled
-   *
-   * @param  {bool}  disabled  Whether the element should be disabled or enabled
-   */
-  disableEditor(disabled) {
-    this.editor.disabled = disabled;
-    this.editor.readOnly = disabled;
-  }
-
-  /**
    * Get the selected text
    */
   getSelection() {
@@ -82,7 +72,10 @@ window.customElements.define('joomla-editor-none', class extends HTMLElement {
       // eslint-disable-next-line no-return-assign
       getSelection: () => this.getSelection(),
       // eslint-disable-next-line no-return-assign
-      disable: disabled => this.disableEditor(disabled),
+      disable: (disabled) => {
+        this.editor.disabled = disabled;
+        this.editor.readOnly = disabled;
+      },
       // eslint-disable-next-line no-return-assign
       replaceSelection: (text) => {
         if (this.editor.selectionStart || this.editor.selectionStart === 0) {

--- a/build/media_source/plg_editors_none/js/joomla-editor-none.w-c.es6.js
+++ b/build/media_source/plg_editors_none/js/joomla-editor-none.w-c.es6.js
@@ -38,6 +38,16 @@ window.customElements.define('joomla-editor-none', class extends HTMLElement {
   }
 
   /**
+   * Sets if the editor should be disabled
+   *
+   * @param  {bool}  disabled  Whether the element should be disabled or enabled
+   */
+  disableEditor(disabled) {
+    this.editor.disabled = disabled;
+    this.editor.readOnly = disabled;
+  }
+
+  /**
    * Get the selected text
    */
   getSelection() {
@@ -71,6 +81,8 @@ window.customElements.define('joomla-editor-none', class extends HTMLElement {
       setValue: text => this.editor.value = text,
       // eslint-disable-next-line no-return-assign
       getSelection: () => this.getSelection(),
+      // eslint-disable-next-line no-return-assign
+      disable: disabled => this.disableEditor(disabled),
       // eslint-disable-next-line no-return-assign
       replaceSelection: (text) => {
         if (this.editor.selectionStart || this.editor.selectionStart === 0) {

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -117,6 +117,8 @@
         setValue: text => Joomla.editors.instances[element.id].instance.setContent(text),
         getSelection: () => Joomla.editors.instances[element.id].instance.selection.getContent({ format: 'text' }),
         replaceSelection: text => Joomla.editors.instances[element.id].instance.execCommand('mceInsertContent', false, text),
+        // Required by Joomla's API for Mail Component Integration
+        disable: disabled => Joomla.editors.instances[element.id].instance.setMode(disabled ? 'readonly' : 'design'),
         // Some extra instance dependent
         id: element.id,
         instance: ed,

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -91,8 +91,17 @@
         buttonValues.push(tmp);
       });
 
+      // Ensure tinymce is initialised in readonly mode if the textarea has readonly applied
+      let readOnlyMode = false;
+
+      if (element) {
+        readOnlyMode = element.readOnly;
+      }
+
       if (buttonValues.length) {
         options.setup = (editor) => {
+          editor.settings.readonly = readOnlyMode;
+
           Object.keys(icons).forEach((icon) => {
             editor.ui.registry.addIcon(icon, icons[icon]);
           });
@@ -102,6 +111,10 @@
             icon: 'joomla',
             fetch: callback => callback(buttonValues),
           });
+        };
+      } else {
+        options.setup = (editor) => {
+          editor.settings.readonly = readOnlyMode;
         };
       }
 

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -51,6 +51,10 @@ window.Joomla.editors.instances = window.Joomla.editors.instances || {
    *                                  Example: (text) => { return this.element.value = text; }
    * getSelection     Type  Function  Should return the selected text from the editor
    *                                  Example: function () { return this.selectedText; }
+   * disable          Type  Function  Toggles the editor into disabled mode. When the editor is
+   *                                  active then everything should be usable. When inactive the
+   *                                  editor should be unusable AND disabled for form validation
+   *                                  Example: (bool) => { return this.disable = value; }
    * replaceSelection Type  Function  Should replace the selected text of the editor
    *                                  If nothing selected, will insert the data at the cursor
    *                                  Example:
@@ -64,7 +68,8 @@ window.Joomla.editors.instances = window.Joomla.editors.instances || {
    *  Joomla.editors.instances['jform_articletext'].getValue();
    * To set the current editor value:
    *  Joomla.editors.instances['jform_articletext'].setValue('Joomla! rocks');
-   * To replace(selection) or insert a value at  the current editor cursor:
+   * To replace(selection) or insert a value at  the current editor cursor (replaces the J3
+   * jInsertEditorText API):
    *  replaceSelection:
    *  Joomla.editors.instances['jform_articletext'].replaceSelection('Joomla! rocks')
    * }
@@ -72,8 +77,6 @@ window.Joomla.editors.instances = window.Joomla.editors.instances || {
    * *********************************************************
    * ANY INTERACTION WITH THE EDITORS SHOULD USE THE ABOVE API
    * *********************************************************
-   *
-   * jInsertEditorText() @deprecated 4.0
    */
 };
 


### PR DESCRIPTION
Adds ability to toggle editor from disabled mode and back again. 

Codemirror is a bit grim here because we set the direct instance into the Joomla.editors stuff so i'm creating a new method in codemirror itself :/ (I know when @dgrammatiko sees this i'm going to be told off :D )

Fixes tags not showing when using html mode

There's still definitely some unwanted behaviour here - for example with the default editor function - the template data looks like:

```
body:
master: "COM_CONFIG_SENDMAIL_BODY"
translated: "This is a test mail sent using "{METHOD}". Your email settings are correct!"
__proto__: Object
htmlbody: {master: "", translated: ""}
subject:
master: "COM_CONFIG_SENDMAIL_SUBJECT"
translated: "Test mail from {SITENAME}"
```

This means that the html email is always showing as empty when your in html mode - to me this needs to take the same at least translated and master text as the main body (if not set to a different value in the email constructor)