### PR TITLE
[4.0] [CMS PR 28350] Move update of utf8 conversion table back do database model

### DIFF
--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -79,29 +79,7 @@ class ConfigurationModel extends BaseInstallationModel
 			return false;
 		}
 
-		// Get query object for later database access
-		$query = $db->getQuery(true);
 		$serverType = $db->getServerType();
-
-		// MySQL only: Attempt to update the table #__utf8_conversion.
-		if ($serverType === 'mysql')
-		{
-			$query->clear()
-				->update($db->quoteName('#__utf8_conversion'))
-				->set($db->quoteName('converted') . ' = ' . ($db->hasUTF8mb4Support() ? 2 : 1));
-			$db->setQuery($query);
-
-			try
-			{
-				$db->execute();
-			}
-			catch (\RuntimeException $e)
-			{
-				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-
-				return false;
-			}
-		}
 
 		// Attempt to update the table #__schema.
 		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/' . $serverType . '/';

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -537,6 +537,27 @@ class DatabaseModel extends BaseInstallationModel
 			return false;
 		}
 
+		// MySQL only: Attempt to update the table #__utf8_conversion.
+		if ($serverType === 'mysql')
+		{
+			$query = $db->getQuery(true);
+			$query->clear()
+				->update($db->quoteName('#__utf8_conversion'))
+				->set($db->quoteName('converted') . ' = ' . ($db->hasUTF8mb4Support() ? 2 : 1));
+			$db->setQuery($query);
+
+			try
+			{
+				$db->execute();
+			}
+			catch (\RuntimeException $e)
+			{
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+				return false;
+			}
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/28350#issuecomment-605649090](https://github.com/joomla/joomla-cms/pull/28350#issuecomment-605649090).

### Summary of Changes

Move the update of the `#__utf8_conversion` tables `converted` value from the confiruration model back to the database model.

I have no idea why that fixes the issue. Maybe this fix just masks another more funcamental issue with order of processing stuff? If so, feel free to discard this PR and solve it in another way.

### Testing Instructions

See [https://github.com/joomla/joomla-cms/pull/28350#issuecomment-605649090](https://github.com/joomla/joomla-cms/pull/28350#issuecomment-605649090).

### Expected result

No error about missing utf8 conversion shown in database checker.

### Actual result

False error about missing utf8 conversion shown in database checker.

### Documentation Changes Required

None.