### PR TITLE
[Joomla CMS PR #28722] Fix update sql for new mail templates

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-04-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-04-16.sql
@@ -1,8 +1,8 @@
-INSERT INTO `#__mail_templates` (`template_id`, `subject`, `body`, `params`) VALUES
-('joomla.updatenotification', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_SUBJECT', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_BODY', '{"tags":["newversion","curversion","sitename","url","link","releasenews"]}'),
-('com_contact.mail', 'COM_CONTACT_ENQUIRY_SUBJECT', 'COM_CONTACT_ENQUIRY_TEXT', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
-('com_contact.mail.copy', 'COM_CONTACT_COPYSUBJECT_OF', 'COM_CONTACT_COPYTEXT_OF', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
-('com_users.massmail.mail', 'COM_USERS_MASSMAIL_MAIL_SUBJECT', 'COM_USERS_MASSMAIL_MAIL_BODY', '{"tags":["subject","body","subjectprefix","bodysuffix"]}'),
-('com_users.administration.new_user.user', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_SUBJECT', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_BODY', '{"tags":["name","sitename","url","username","password","email"]}'),
-('com_users.password_reset', 'COM_USERS_EMAIL_PASSWORD_RESET_SUBJECT', 'COM_USERS_EMAIL_PASSWORD_RESET_BODY', '{"tags":["name","email","sitename","link_text","link_html","token"]}'),
-('com_users.reminder', 'COM_USERS_EMAIL_USERNAME_REMINDER_SUBJECT', 'COM_USERS_EMAIL_USERNAME_REMINDER_BODY', '{"tags":["name","username","sitename","email","link_text","link_html"]}');
+INSERT INTO `#__mail_templates` (`template_id`, `language`, `subject`, `body`, `htmlbody`, `attachments`, `params`) VALUES
+('joomla.updatenotification', '', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_SUBJECT', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_BODY', '', '', '{"tags":["newversion","curversion","sitename","url","link","releasenews"]}'),
+('com_contact.mail', '', 'COM_CONTACT_ENQUIRY_SUBJECT', 'COM_CONTACT_ENQUIRY_TEXT', '', '', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
+('com_contact.mail.copy', '', 'COM_CONTACT_COPYSUBJECT_OF', 'COM_CONTACT_COPYTEXT_OF', '', '', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
+('com_users.massmail.mail', '', 'COM_USERS_MASSMAIL_MAIL_SUBJECT', 'COM_USERS_MASSMAIL_MAIL_BODY', '', '', '{"tags":["subject","body","subjectprefix","bodysuffix"]}'),
+('com_users.administration.new_user.user', '', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_SUBJECT', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_BODY', '', '', '{"tags":["name","sitename","url","username","password","email"]}'),
+('com_users.password_reset', '', 'COM_USERS_EMAIL_PASSWORD_RESET_SUBJECT', 'COM_USERS_EMAIL_PASSWORD_RESET_BODY', '', '', '{"tags":["name","email","sitename","link_text","link_html","token"]}'),
+('com_users.reminder', '', 'COM_USERS_EMAIL_USERNAME_REMINDER_SUBJECT', 'COM_USERS_EMAIL_USERNAME_REMINDER_BODY', '', '', '{"tags":["name","username","sitename","email","link_text","link_html"]}');

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-04-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-04-16.sql
@@ -1,8 +1,8 @@
-INSERT INTO "#__mail_templates" ("template_id", "subject", "body", "params") VALUES
-('joomla.updatenotification', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_SUBJECT', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_BODY', '{"tags":["newversion","curversion","sitename","url","link","releasenews"]}'),
-('com_contact.mail', 'COM_CONTACT_ENQUIRY_SUBJECT', 'COM_CONTACT_ENQUIRY_TEXT', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
-('com_contact.mail.copy', 'COM_CONTACT_COPYSUBJECT_OF', 'COM_CONTACT_COPYTEXT_OF', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
-('com_users.massmail.mail', 'COM_USERS_MASSMAIL_MAIL_SUBJECT', 'COM_USERS_MASSMAIL_MAIL_BODY', '{"tags":["subject","body","subjectprefix","bodysuffix"]}'),
-('com_users.administration.new_user.user', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_SUBJECT', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_BODY', '{"tags":["name","sitename","url","username","password","email"]}'),
-('com_users.password_reset', 'COM_USERS_EMAIL_PASSWORD_RESET_SUBJECT', 'COM_USERS_EMAIL_PASSWORD_RESET_BODY', '{"tags":["name","email","sitename","link_text","link_html","token"]}'),
-('com_users.reminder', 'COM_USERS_EMAIL_USERNAME_REMINDER_SUBJECT', 'COM_USERS_EMAIL_USERNAME_REMINDER_BODY', '{"tags":["name","username","sitename","email","link_text","link_html"]}');
+INSERT INTO "#__mail_templates" ("template_id", "language", "subject", "body", "htmlbody", "attachments", "params") VALUES
+('joomla.updatenotification', '', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_SUBJECT', 'PLG_SYSTEM_UPDATENOTIFICATION_EMAIL_BODY', '', '', '{"tags":["newversion","curversion","sitename","url","link","releasenews"]}'),
+('com_contact.mail', '', 'COM_CONTACT_ENQUIRY_SUBJECT', 'COM_CONTACT_ENQUIRY_TEXT', '', '', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
+('com_contact.mail.copy', '', 'COM_CONTACT_COPYSUBJECT_OF', 'COM_CONTACT_COPYTEXT_OF', '', '', '{"tags":["sitename","name","email","subject","body","url","customfields"]}'),
+('com_users.massmail.mail', '', 'COM_USERS_MASSMAIL_MAIL_SUBJECT', 'COM_USERS_MASSMAIL_MAIL_BODY', '', '', '{"tags":["subject","body","subjectprefix","bodysuffix"]}'),
+('com_users.administration.new_user.user', '', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_SUBJECT', 'PLG_USER_JOOMLA_NEW_USER_EMAIL_BODY', '', '', '{"tags":["name","sitename","url","username","password","email"]}'),
+('com_users.password_reset', '', 'COM_USERS_EMAIL_PASSWORD_RESET_SUBJECT', 'COM_USERS_EMAIL_PASSWORD_RESET_BODY', '', '', '{"tags":["name","email","sitename","link_text","link_html","token"]}'),
+('com_users.reminder', '', 'COM_USERS_EMAIL_USERNAME_REMINDER_SUBJECT', 'COM_USERS_EMAIL_USERNAME_REMINDER_BODY', '', '', '{"tags":["name","username","sitename","email","link_text","link_html"]}');


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722).

### Summary of Changes

Adjust the update sql script's insert statement to the one used in supports.sql. This fixes SQL warnings or errors (depending on strict mode) "1364 Field <column>' doesn't have a default value" for columns `htmlbody` and `attachments`.