### PR TITLE
[4.0] [PR 28722] Fix PHP notices and warnings when sending password reset mail

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -313,21 +313,23 @@ class MailTemplate
 			if (is_array($value))
 			{
 				$matches = array();
-				preg_match_all('/{' . strtoupper($key) . '}(.*?){/' . strtoupper($key) . '}/s', $text, $matches);
 
-				foreach ($matches[0] as $i => $match)
+				if (preg_match_all('/{' . strtoupper($key) . '}(.*?){/' . strtoupper($key) . '}/s', $text, $matches))
 				{
-					$replacement = '';
-
-					foreach ($value as $subvalue)
+					foreach ($matches[0] as $i => $match)
 					{
-						if (is_array($subvalue))
-						{
-							$replacement .= $this->replaceTags($matches[1][$i], $subvalue);
-						}
-					}
+						$replacement = '';
 
-					$text = str_replace($match, $replacement, $text);
+						foreach ($value as $subvalue)
+						{
+							if (is_array($subvalue))
+							{
+								$replacement .= $this->replaceTags($matches[1][$i], $subvalue);
+							}
+						}
+
+						$text = str_replace($match, $replacement, $text);
+					}
 				}
 			}
 			else

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -314,7 +314,7 @@ class MailTemplate
 			{
 				$matches = array();
 
-				if (preg_match_all('/{' . strtoupper($key) . '}(.*?){/' . strtoupper($key) . '}/s', $text, $matches))
+				if (preg_match_all('/{' . strtoupper($key) . '}(.*?){\/' . strtoupper($key) . '}/s', $text, $matches))
 				{
 					foreach ($matches[0] as $i => $match)
 					{


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722).

### Summary of Changes

Fix following when sending a password reset email having [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722) applied:
```
[22-May-2020 12:16:12 Europe/Berlin] PHP Warning:  preg_match_all(): Unknown modifier 'G' in /test6/libraries/src/Mail/MailTemplate.php on line 316
[22-May-2020 12:16:12 Europe/Berlin] PHP Notice:  Undefined offset: 0 in /test6/libraries/src/Mail/MailTemplate.php on line 318
[22-May-2020 12:16:12 Europe/Berlin] PHP Warning:  Invalid argument supplied for foreach() in /test6/libraries/src/Mail/MailTemplate.php on line 318
[22-May-2020 12:16:12 Europe/Berlin] PHP Warning:  preg_match_all(): Unknown modifier 'G' in /test6/libraries/src/Mail/MailTemplate.php on line 316
[22-May-2020 12:16:12 Europe/Berlin] PHP Notice:  Undefined offset: 0 in /test6/libraries/src/Mail/MailTemplate.php on line 318
[22-May-2020 12:16:12 Europe/Berlin] PHP Warning:  Invalid argument supplied for foreach() in /test6/libraries/src/Mail/MailTemplate.php on line 318
```
The erroneous code doesn't come from [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722), but it gets only executed if that PR is applied, so it makes sense to correct these issues with that PR.

The `preg_match_all(): Unknown modifier 'G'` comes from the slash of an end tag, e.g. `{/GROUPS}` in this case, not being quoted in the regular expression, e.g. `/{GROUPS}(.?){/GROUPS}/s`. It should be e.g. `/{GROUPS}(.?){\/GROUPS}/s`.

The `Undefined offset: 0` comes from the `foreach ($matches[0] ... )` being executed even if there was no match. This is fixed by using `if (preg_match_all( ... ))` and putting the rest into that `if`. `preg_match_all` returns either null or false if no match, and a number greater than zero if some match.