### PR TITLE
[4.0] [PR 28722] Load client language file for com_contact in API submitt contact form

### DIFF
--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -205,6 +205,8 @@ class ContactController extends ApiController
 	{
 		$app = $this->app;
 
+		Factory::getLanguage()->load('com_contact', JPATH_SITE, $app->getLanguage()->getTag(), true);
+
 		if ($contact->email_to == '' && $contact->user_id != 0)
 		{
 			$contact_user      = User::getInstance($contact->user_id);


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722).

### Summary of Changes

This fixes that with PR [https://github.com/joomla/joomla-cms/pull/28722](https://github.com/joomla/joomla-cms/pull/28722), the subject and body language strings are not translated when sending a contact form email with the API.

See my comment there about the issue: [https://github.com/joomla/joomla-cms/pull/28722#issuecomment-633524638](https://github.com/joomla/joomla-cms/pull/28722#issuecomment-633524638).

But **_I don't know if it's the right way to fix it, so please check that_** and use a different solution for that problem if this here is wrong.