### PR TITLE
php-cs-fixer configuration update - deprecated rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -70,8 +70,8 @@ $config
             '@PSR12'                         => true,
             // Short array syntax
             'array_syntax'                   => ['syntax' => 'short'],
-            // Lists should not have a trailing comma like list($foo, $bar,) = ...
-            'no_trailing_comma_in_list_call' => true,
+            // List of values separated by a comma is contained on a single line should not have a trailing comma like [$foo, $bar,] = ...
+            'no_trailing_comma_in_singleline' => true,
             // Arrays on multiline should have a trailing comma
             'trailing_comma_in_multiline'    => ['elements' => ['arrays']],
             // Align elements in multiline array and variable declarations on new lines below each other

--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -666,7 +666,7 @@ class SysinfoModel extends BaseDatabaseModel
      */
     private function addDirectory(string $name, string $path, string $message = ''): void
     {
-        $this->directories[$name] = ['writable' => is_writable($path), 'message' => $message,];
+        $this->directories[$name] = ['writable' => is_writable($path), 'message' => $message];
     }
 
     /**
@@ -718,7 +718,7 @@ class SysinfoModel extends BaseDatabaseModel
                 foreach ($vals as $val) {
                     // 3cols
                     if (preg_match($p2, $val, $matches)) {
-                        $r[$name][trim($matches[1])] = [trim($matches[2]), trim($matches[3]),];
+                        $r[$name][trim($matches[1])] = [trim($matches[2]), trim($matches[3])];
                     } elseif (preg_match($p3, $val, $matches)) {
                         // 2cols
                         $r[$name][trim($matches[1])] = trim($matches[2]);


### PR DESCRIPTION
Use "no_trailing_comma_in_singleline" instead of deprecated rule "no_trailing_comma_in_list_call"

* configuration change -> e9de9993c23c53f1ae984790c0d077eee6e79a12

* code changes / fix -> 560db288dad716503dc51cf59506d45d22d923e9