### PR TITLE
Fix PostgreSQL failure

### DIFF
--- a/administrator/components/com_menus/presets/alternate.xml
+++ b/administrator/components/com_menus/presets/alternate.xml
@@ -225,7 +225,7 @@
 			type="separator"
 			title="JSITE"
 			hidden="false"
-			sql_select="a.id, a.title, a.menutype, CASE COALESCE(SUM(m.home), 0) WHEN 0 THEN '' WHEN 1 THEN CASE m.language WHEN '*' THEN 'class:icon-home' ELSE CONCAT('image:', l.lang_code) END ELSE 'class:icon-home' END AS icon"
+			sql_select="a.id, a.title, a.menutype, CASE COALESCE(SUM(m.home), 0) WHEN 0 THEN '' WHEN 1 THEN CASE MAX(m.language) WHEN '*' THEN 'class:icon-home' ELSE CONCAT('image:', MAX(l.lang_code)) END ELSE 'class:icon-home' END AS icon"
 			sql_from="#__menu_types AS a"
 			sql_where="a.client_id = 0"
 			sql_leftjoin="#__menu AS m ON m.menutype = a.menutype AND m.home = 1 LEFT JOIN #__languages AS l ON l.lang_code = m.language"

--- a/administrator/components/com_menus/presets/default.xml
+++ b/administrator/components/com_menus/presets/default.xml
@@ -136,7 +136,7 @@
 			type="separator"
 			title="JSITE"
 			hidden="false"
-			sql_select="a.id, a.title, a.menutype, CASE COALESCE(SUM(m.home), 0) WHEN 0 THEN '' WHEN 1 THEN CASE m.language WHEN '*' THEN 'class:icon-home' ELSE CONCAT('image:', l.lang_code) END ELSE 'class:icon-home' END AS icon"
+			sql_select="a.id, a.title, a.menutype, CASE COALESCE(SUM(m.home), 0) WHEN 0 THEN '' WHEN 1 THEN CASE MAX(m.language) WHEN '*' THEN 'class:icon-home' ELSE CONCAT('image:', MAX(l.lang_code)) END ELSE 'class:icon-home' END AS icon"
 			sql_from="#__menu_types AS a"
 			sql_where="a.client_id = 0"
 			sql_leftjoin="#__menu AS m ON m.menutype = a.menutype AND m.home = 1 LEFT JOIN #__languages AS l ON l.lang_code = m.language"


### PR DESCRIPTION
With the PR https://github.com/joomla/joomla-cms/pull/43862 there are two exceptions if as database PostgreSQL is used.
```
`ERROR: column "m.language" must appear in the GROUP BY clause or be used in an aggregate function`
```

If the columns in GROUP BY are simple added again, there are multiple menu entries shown if multiple home set in one menu.

Solution is to use the aggregate function MAX.

Tested with
* ✅ PostgreSQL PDO
* ✅ MySQL with MySQLi
* ✅ MySQL with MySQL PDO
* ✅ MariaDB with MySQL PDO
* ✅ MariaDB with MySQLi

On base of:

- PR 43862 with Patch Tester
- npm update joomla-cypress 1.1.1
- this PR fix-postgres
- npx cypress run --spec tests/System/integration/install/multi-lang-menu.cy.js  (attached as .txt)
```
Test Support PR 43862 with
✓ install Japanese language pack  (9784ms)
✓ install Ukrainian language pack (8487ms)
✓ install German language pack (8309ms)
✓ enable plugin 'System - Language filter' (1903ms) ✓ create '2nd menu' (1484ms)
✓ create 1st menu entry de as HOME in '2nd menu' (5601ms)
✓ create 2nd menu entry ja as HOME in '2nd menu' (4936ms)
✓ create 3rd menu entry uk as HOME in '2nd menu' (5392ms)
✓ create '3rd menu' (1434ms)
```
* checked five times that the HOME symbol is displayed if more than one Home menu entry is set, otherwise the correct language (uk-UA, ja-JP or de-DE) is displayed for each of the three entries if there is only one menu entry with Home

see [multi-lang-menu.cy.js.txt](https://github.com/user-attachments/files/16591338/multi-lang-menu.cy.js.txt) and
![screenshot](https://github.com/user-attachments/assets/29f3a586-3f3b-480f-801e-aebd4aedd8a8)



